### PR TITLE
m8: Fix for tap to wake randomly dying after a while.

### DIFF
--- a/drivers/i2c/chips/CwMcuSensor.c
+++ b/drivers/i2c/chips/CwMcuSensor.c
@@ -2980,23 +2980,19 @@ static void cwmcu_irq_work_func(struct work_struct *work)
 				if (tap2wake == 1) {
 					D("[CWMCU] Tap to wake - waking device\n");
 					vib_trigger_event(vib_trigger, VIB_TIME);
+					sensor->sensors_time[Gesture_Motion_HIDI] = 0;
 					input_report_rel(sensor->input, HTC_Gesture_Motion_HIDI, data_event);
+					input_sync(sensor->input);
+					power_key_pressed = 0;
 				} else {
 					D("[CWMCU] Tap to wake disabled, ignoring\n");
 				}
 			} else {
 				D("[CWMCU] Discard gesture wake\n");
 			}
-			sensor->sensors_time[Gesture_Motion_HIDI] = 0;
-			input_sync(sensor->input);
- 			power_key_pressed = 0;
 		}
 		clear_intr = CW_MCU_INT_BIT_HTC_GESTURE_MOTION_HIDI;
 		ret = CWMCU_i2c_write(sensor, CWSTM32_INT_ST4, &clear_intr, 1);
-		msleep(5);
-		gpio_direction_output(sensor->gpio_reset, 0);
-		msleep(1);
-		gpio_direction_output(sensor->gpio_reset, 1);
 	}
 
 	


### PR DESCRIPTION
Removed inappropriate reset of sensor GPIOs

Change-Id: Ia0eb6be3c95c0f9318b375027115957ef999547d